### PR TITLE
WAR-120 Deploying and configuring RabbitMQ

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,26 @@ services:
       timeout: 1s
       retries: 30
 
+  rabbitmq:
+    image: rabbitmq:4.0.5-management
+    container_name: rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: rabbituser
+      RABBITMQ_DEFAULT_PASS: rabbitpass
+      TZ: Asia/Aqtobe
+    networks:
+      - internal
+    ports:
+      - "5672:5672"   # AMQP protocol
+      - "15672:15672" # Management UI
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 1s
+      timeout: 1s
+      retries: 100
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+
   backend:
   # Backend will be running on nginx
   # Internal exposed port is 8080
@@ -149,3 +169,4 @@ networks:
 
 volumes:
   db_data:
+  rabbitmq_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,6 +40,7 @@ services:
       timeout: 1s
       retries: 100
     volumes:
+      - ./services/rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
       - rabbitmq_data:/var/lib/rabbitmq
 
   backend:

--- a/services/rabbitmq/rabbitmq.conf
+++ b/services/rabbitmq/rabbitmq.conf
@@ -1,0 +1,6 @@
+listeners.tcp.default = 5672
+num_acceptors.tcp = 10
+socket_writer.gc_threshold = 1000000000
+loopback_users.guest = false
+management.tcp.port = 15672
+vm_memory_high_watermark.relative = 0.6


### PR DESCRIPTION
RabbitMQ was deployed in docker on ports `5672` for broker and `15672` for UI.
Added configuration for RabbitMQ to `services/rabbitmq/rabbitmq.conf`.