### PR TITLE
WAR-144 Configure logging for the validation library

### DIFF
--- a/shared/validation/package.json
+++ b/shared/validation/package.json
@@ -5,7 +5,8 @@
     "tslib": "^2.3.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
-    "express": "~4.18.1"
+    "express": "~4.18.1",
+    "@warehouse/logging": "^0.0.1"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/shared/validation/src/lib/validation.spec.ts
+++ b/shared/validation/src/lib/validation.spec.ts
@@ -1,4 +1,4 @@
-import { validateRequest } from './validation';
+import { validateRequest, validateQuery, validateParams } from './validation';
 import { Request, Response } from 'express';
 import { plainToInstance } from 'class-transformer';
 import { validate, ValidationError } from 'class-validator';
@@ -28,9 +28,80 @@ describe('validation', () => {
     let next: jest.Mock;
 
     beforeEach(() => {
-      req = {
-        body: {},
+      req = { body: {} };
+      res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
       };
+      next = jest.fn();
+    });
+
+    describe('deprecated req.body', () => {
+      it('should attach validated body to req.validatedBody', async () => {
+        const DTOClass = jest.fn();
+        (plainToInstance as jest.Mock).mockReturnValue({});
+        (validate as jest.Mock).mockResolvedValue([]);
+
+        const middleware = validateRequest(DTOClass);
+        await middleware(req as Request, res as Response, next);
+
+        expect(req.validatedBody).toBeDefined();
+        expect(req.validatedBody).toEqual({});
+      });
+
+      it('should not attach validated body to req.body', async () => {
+        const DTOClass = jest.fn();
+        (plainToInstance as jest.Mock).mockReturnValue({});
+        (validate as jest.Mock).mockResolvedValue([]);
+
+        const middleware = validateRequest(DTOClass);
+        await middleware(req as Request, res as Response, next);
+
+        expect(req.body).toEqual({});
+      });
+    });
+
+    it('should call next if validation passes', async () => {
+      const DTOClass = jest.fn();
+      (plainToInstance as jest.Mock).mockReturnValue({});
+      (validate as jest.Mock).mockResolvedValue([]);
+
+      const middleware = validateRequest(DTOClass);
+      await middleware(req as Request, res as Response, next);
+
+      expect(plainToInstance).toHaveBeenCalledWith(DTOClass, req.body, { enableImplicitConversion: true });
+      expect(validate).toHaveBeenCalledWith({});
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should return 400 if validation fails', async () => {
+      const DTOClass = jest.fn();
+      const errorObj = { constraints: { error: "Error message" } };
+      (plainToInstance as jest.Mock).mockReturnValue({});
+      (validate as jest.Mock).mockResolvedValue([errorObj]);
+
+      const middleware = validateRequest(DTOClass);
+      await middleware(req as Request, res as Response, next);
+
+      expect(plainToInstance).toHaveBeenCalledWith(DTOClass, req.body, { enableImplicitConversion: true });
+      expect(validate).toHaveBeenCalledWith({});
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        code: 400,
+        type: 'error',
+        message: 'Invalid request data - Error message'
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validateQuery', () => {
+    let req: Partial<Request>;
+    let res: Partial<Response>;
+    let next: jest.Mock;
+
+    beforeEach(() => {
+      req = { query: {} };
       res = {
         status: jest.fn().mockReturnThis(),
         json: jest.fn(),
@@ -43,30 +114,78 @@ describe('validation', () => {
       (plainToInstance as jest.Mock).mockReturnValue({});
       (validate as jest.Mock).mockResolvedValue([]);
 
-      const middleware = validateRequest(DTOClass);
+      const middleware = validateQuery(DTOClass);
       await middleware(req as Request, res as Response, next);
 
-      expect(plainToInstance).toHaveBeenCalledWith(DTOClass, req.body);
+      expect(plainToInstance).toHaveBeenCalledWith(DTOClass, req.query, { enableImplicitConversion: true });
       expect(validate).toHaveBeenCalledWith({});
       expect(next).toHaveBeenCalled();
     });
 
     it('should return 400 if validation fails', async () => {
       const DTOClass = jest.fn();
-      const validationError = new ValidationError();
+      const errorObj = { constraints: { error: "Error message" } };
       (plainToInstance as jest.Mock).mockReturnValue({});
-      (validate as jest.Mock).mockResolvedValue([validationError]);
+      (validate as jest.Mock).mockResolvedValue([errorObj]);
 
-      const middleware = validateRequest(DTOClass);
+      const middleware = validateQuery(DTOClass);
       await middleware(req as Request, res as Response, next);
 
-      expect(plainToInstance).toHaveBeenCalledWith(DTOClass, req.body);
+      expect(plainToInstance).toHaveBeenCalledWith(DTOClass, req.query, { enableImplicitConversion: true });
       expect(validate).toHaveBeenCalledWith({});
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith({
         code: 400,
         type: 'error',
-        message: 'Invalid request data',
+        message: 'Invalid query parameters - Error message'
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validateParams', () => {
+    let req: Partial<Request>;
+    let res: Partial<Response>;
+    let next: jest.Mock;
+
+    beforeEach(() => {
+      req = { params: {} };
+      res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+      next = jest.fn();
+    });
+
+    it('should call next if validation passes', async () => {
+      const DTOClass = jest.fn();
+      (plainToInstance as jest.Mock).mockReturnValue({});
+      (validate as jest.Mock).mockResolvedValue([]);
+
+      const middleware = validateParams(DTOClass);
+      await middleware(req as Request, res as Response, next);
+
+      expect(plainToInstance).toHaveBeenCalledWith(DTOClass, req.params, { enableImplicitConversion: true });
+      expect(validate).toHaveBeenCalledWith({});
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should return 400 if validation fails', async () => {
+      const DTOClass = jest.fn();
+      const errorObj = { constraints: { error: "Error message" } };
+      (plainToInstance as jest.Mock).mockReturnValue({});
+      (validate as jest.Mock).mockResolvedValue([errorObj]);
+
+      const middleware = validateParams(DTOClass);
+      await middleware(req as Request, res as Response, next);
+
+      expect(plainToInstance).toHaveBeenCalledWith(DTOClass, req.params, { enableImplicitConversion: true });
+      expect(validate).toHaveBeenCalledWith({});
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        code: 400,
+        type: 'error',
+        message: 'Invalid URL parameters - Error message'
       });
       expect(next).not.toHaveBeenCalled();
     });

--- a/shared/validation/src/lib/validation.spec.ts
+++ b/shared/validation/src/lib/validation.spec.ts
@@ -1,7 +1,7 @@
 import { validateRequest, validateQuery, validateParams } from './validation';
 import { Request, Response } from 'express';
 import { plainToInstance } from 'class-transformer';
-import { validate, ValidationError } from 'class-validator';
+import { validate } from 'class-validator';
 
 jest.mock('class-transformer', () => ({
   plainToInstance: jest.fn(),

--- a/shared/validation/src/lib/validation.ts
+++ b/shared/validation/src/lib/validation.ts
@@ -1,31 +1,229 @@
 import { plainToInstance } from 'class-transformer';
 import { validate, ValidationError } from 'class-validator';
-import { Request, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 import { ApiResponse } from './baseDTO';
+import { getLogger } from '@warehouse/logging';
 
+const logger = getLogger('validation');
+
+/**
+ * Extends the Express Request interface to include validated body, query, and params.
+ * This is useful for accessing validated data in the request handlers.
+ * Additions:
+ * - `validatedBody` - The validated request body.
+ * - `validatedQuery` - The validated query parameters.
+ * - `validatedParams` - The validated URL parameters.
+ */
+declare module 'express-serve-static-core' {
+  interface Request {
+    validatedBody?: unknown;
+    validatedQuery?: unknown;
+    validatedParams?: unknown;
+  }
+}
+
+
+/**
+ * Validates the request body using the provided DTO class.
+ * The validated body is attached to the request object as `validatedBody`.
+ * `validatedBody` is of the same type as the provided DTO class.
+ * 
+ * Deprecated: Use `req.validatedBody` instead of `req.body`.
+ * @param DTOClass 
+ * @returns An Express middleware function
+ * @example
+ * ```typescript
+ * class CreateUserDTO {
+ *   \@IsString()
+ *   name!: string;
+ * }
+ * 
+ * router.post('/', validateRequest(CreateUserDTO), async (req, res) => {
+ *   if (req.validatedBody instanceof CreateUserDTO) {} // Always true
+ *   console.log(req.validatedBody.name); // Access the validated name
+ *   // Do something with the validated name
+ * });
+ * ```
+ */
 export function validateRequest<T extends object>(DTOClass: new () => T) {
   return async (
     req: Request,
     res: Response,
-    next: () => void
+    next: NextFunction
   ): Promise<void> => {
-    const dtoInstance = plainToInstance(DTOClass, req.body);
+    // Not safe, as req.body can contain sensitive data
+    // But for debugging purposes, it's fine. I think.
+    logger.debug('Validating request data', { DTOClass, body: req.body, method: req.method, url: req.url });
+
+    const dtoInstance = plainToInstance(DTOClass, req.body, {
+      enableImplicitConversion: true,
+    });
     const errors: ValidationError[] = await validate(dtoInstance);
 
+    logger.debug('Translated request data to DTO instance', {
+      dtoInstance,
+      errors,
+    });
+
     if (errors.length > 0) {
-      const message = new ValidationError();
-      message.children = errors;
+      const errorMessages = errors.map((error) =>
+        Object.values(error.constraints ?? {}).join(', ')
+      );
+
+      logger.error('Invalid request data', { errors: errorMessages });
+
       res.status(400).json(
         ApiResponse.from({
           code: 400,
           type: 'error',
-          message: `Invalid request data`,
+          message: `Invalid request data - ${errorMessages.join('; ')}`,
         })
       );
       return;
     }
 
-    req.body = dtoInstance;
+    req.validatedBody = dtoInstance as T;
+    req.body = dtoInstance; // Deprecated, use validatedBody instead.
+    logger.debug(
+      'Request data validated successfully, continuing with request processing'
+    );
+    next();
+  };
+}
+
+
+/**
+ * Validates query parameters using the provided DTO class.
+ * The validated parameters are attached to the request object as `validatedQuery`.
+ * `validatedQuery` is of the same type as the provided DTO class.
+ * @param DTOClass The DTO class to use for validation
+ * @returns An Express middleware function
+ * @example
+ * ```typescript
+ * class GetUserDTO {
+ *   \@IsInt()
+ *   id!: number;
+ * }
+ * 
+ * router.get('/', validateQuery(GetUserDTO), async (req, res) => {
+ *   if (req.validatedQuery instanceof GetUserDTO) {} // Always true
+ *   console.log(req.validatedQuery.id); // Access the validated ID
+ *   // Do something with the validated ID
+ * });
+ * ```
+*/
+export function validateQuery<T extends object>(DTOClass: new () => T) {
+  return async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> => {
+    logger.debug('Validating query parameters', {
+      DTOClass,
+      query: req.query,
+      method: req.method,
+      url: req.url,
+    });
+
+    const dtoInstance = plainToInstance(DTOClass, req.query, {
+      enableImplicitConversion: true,
+    });
+    const errors: ValidationError[] = await validate(dtoInstance);
+
+    logger.debug('Translated query parameters to DTO instance', {
+      dtoInstance,
+      errors,
+    });
+
+    if (errors.length > 0) {
+      const errorMessages = errors.map((error) =>
+        Object.values(error.constraints ?? {}).join(', ')
+      );
+
+      logger.error('Invalid query parameters', { errors: errorMessages });
+
+      res.status(400).json(
+        ApiResponse.from({
+          code: 400,
+          type: 'error',
+          message: `Invalid query parameters - ${errorMessages.join('; ')}`,
+        })
+      );
+      return;
+    }
+
+    req.validatedQuery = dtoInstance as T;
+    logger.debug(
+      'Query parameters validated successfully, continuing with request processing'
+    );
+    next();
+  };
+}
+
+/**
+ * Validates URL parameters using the provided DTO class.
+ * The validated parameters are attached to the request object as `validatedParams`.
+ * `validatedParams` is of the same type as the provided DTO class.
+ * @param DTOClass The DTO class to use for validation
+ * @returns An Express middleware function
+ * @example
+ * ```typescript
+ * class GetUserDTO {
+ *   \@IsInt()
+ *   id!: number;
+ * }
+ * 
+ * router.get('/:id', validateParams(GetUserDTO), async (req, res) => {
+ *   if (req.validatedParams instanceof GetUserDTO) {} // Always true
+ *   console.log(req.validatedParams.id); // Access the validated ID
+ *   // Do something with the validated ID
+ * });
+ * ```
+ */
+export function validateParams<T extends object>(DTOClass: new () => T) {
+  return async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> => {
+    logger.debug('Validating URL parameters', {
+      DTOClass,
+      params: req.params,
+      method: req.method,
+      url: req.url,
+    });
+
+    const dtoInstance = plainToInstance(DTOClass, req.params, {
+      enableImplicitConversion: true,
+    });
+    const errors: ValidationError[] = await validate(dtoInstance);
+
+    logger.debug('Translated URL parameters to DTO instance', {
+      dtoInstance,
+      errors,
+    });
+
+    if (errors.length > 0) {
+      const errorMessages = errors.map((error) =>
+        Object.values(error.constraints ?? {}).join(', ')
+      );
+
+      logger.error('Invalid URL parameters', { errors: errorMessages });
+
+      res.status(400).json(
+        ApiResponse.from({
+          code: 400,
+          type: 'error',
+          message: `Invalid URL parameters - ${errorMessages.join('; ')}`,
+        })
+      );
+      return;
+    }
+
+    req.validatedParams = dtoInstance as T;
+    logger.debug(
+      'URL parameters validated successfully, continuing with request processing'
+    );
     next();
   };
 }


### PR DESCRIPTION
Added 2 new functions for validation:
- Validation of url parameters `validateParams(DTO);`
- Validation of query parameters `validateQuery(DTO);`

Tests have been created for all these functions.
The `req.body` parameter has been deprecated, and `req.validatedBody` should be used instead.