### PR TITLE
WAR-121 Creating a shared library for RabbitMQ using TypeScript.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "amqplib": "^0.10.5",
         "axios": "^1.6.0",
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
@@ -21,7 +22,8 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-router-dom": "6.11.2",
-        "typeorm": "^0.3.20"
+        "typeorm": "^0.3.20",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.8.0",
@@ -45,6 +47,7 @@
         "@swc/core": "~1.5.7",
         "@swc/helpers": "~0.5.11",
         "@testing-library/react": "15.0.6",
+        "@types/amqplib": "^0.10.6",
         "@types/bcrypt": "^5.0.2",
         "@types/cookie-parser": "^1.4.8",
         "@types/express": "~4.17.13",
@@ -53,6 +56,7 @@
         "@types/node": "~18.16.9",
         "@types/react": "18.3.1",
         "@types/react-dom": "18.3.0",
+        "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^4.2.0",
         "@vitest/ui": "^1.3.1",
         "babel-jest": "^29.7.0",
@@ -82,6 +86,24 @@
         "webpack-cli": "^5.1.4",
         "winston": "^3.17.0"
       }
+    },
+    "node_modules/@acuminous/bitsyntax": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@acuminous/bitsyntax/-/bitsyntax-0.1.2.tgz",
+      "integrity": "sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==",
+      "dependencies": {
+        "buffer-more-ints": "~1.0.0",
+        "debug": "^4.3.4",
+        "safe-buffer": "~5.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/@acuminous/bitsyntax/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.3.3",
@@ -2003,6 +2025,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@cypress/request/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cypress/xvfb": {
@@ -7736,6 +7767,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/amqplib": {
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.10.6.tgz",
+      "integrity": "sha512-vQLVypBS1JQcfTXhl1Td1EEeLdtb+vuulOb4TrzYiLyP2aYLMAEzB3pNmEA0jBm0xIXu946Y7Xwl19Eidl32SQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -8202,6 +8242,12 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true
     },
     "node_modules/@types/validator": {
@@ -9114,6 +9160,19 @@
       },
       "peerDependencies": {
         "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/amqplib": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.5.tgz",
+      "integrity": "sha512-Dx5zmy0Ur+Q7LPPdhz+jx5IzmJBoHd15tOeAfQ8SuvEtyPJ20hBemhOBA4b1WeORCRa0ENM/kHCzmem1w/zHvQ==",
+      "dependencies": {
+        "@acuminous/bitsyntax": "^0.1.2",
+        "buffer-more-ints": "~1.0.0",
+        "url-parse": "~1.5.10"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ansi-colors": {
@@ -10248,6 +10307,11 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/buffer-more-ints": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -20771,8 +20835,7 @@
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -21140,8 +21203,7 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -22055,6 +22117,15 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      }
+    },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/sort-keys": {
@@ -24009,7 +24080,6 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -24029,12 +24099,15 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {},
   "private": true,
   "dependencies": {
+    "amqplib": "^0.10.5",
     "axios": "^1.6.0",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
@@ -17,7 +18,8 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.11.2",
-    "typeorm": "^0.3.20"
+    "typeorm": "^0.3.20",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",
@@ -41,6 +43,7 @@
     "@swc/core": "~1.5.7",
     "@swc/helpers": "~0.5.11",
     "@testing-library/react": "15.0.6",
+    "@types/amqplib": "^0.10.6",
     "@types/bcrypt": "^5.0.2",
     "@types/cookie-parser": "^1.4.8",
     "@types/express": "~4.17.13",
@@ -49,6 +52,7 @@
     "@types/node": "~18.16.9",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.0",
+    "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^4.2.0",
     "@vitest/ui": "^1.3.1",
     "babel-jest": "^29.7.0",

--- a/shared/rpc/README.md
+++ b/shared/rpc/README.md
@@ -1,0 +1,11 @@
+# rpc
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build rpc` to build the library.
+
+## Running unit tests
+
+Run `nx test rpc` to execute the unit tests via [Jest](https://jestjs.io).

--- a/shared/rpc/eslint.config.cjs
+++ b/shared/rpc/eslint.config.cjs
@@ -1,0 +1,19 @@
+const baseConfig = require('../../eslint.config.cjs');
+
+module.exports = [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs}'],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: require('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/shared/rpc/jest.config.ts
+++ b/shared/rpc/jest.config.ts
@@ -1,0 +1,10 @@
+export default {
+  displayName: 'rpc',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/shared/rpc',
+};

--- a/shared/rpc/package-lock.json
+++ b/shared/rpc/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "@warehouse/rpc",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@warehouse/rpc",
+      "version": "0.0.1",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "devDependencies": {
+        "@types/uuid": "^10.0.0"
+      }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    }
+  }
+}

--- a/shared/rpc/package.json
+++ b/shared/rpc/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@warehouse/rpc",
+  "version": "0.0.1",
+  "dependencies": {
+    "tslib": "^2.3.0",
+    "@warehouse/logging": "^0.0.1",
+    "amqplib": "^0.10.5",
+    "uuid": "^11.1.0"
+  },
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "typings": "./src/index.d.ts",
+  "private": true,
+  "devDependencies": {
+    "@types/uuid": "^10.0.0"
+  }
+}

--- a/shared/rpc/project.json
+++ b/shared/rpc/project.json
@@ -1,0 +1,19 @@
+{
+  "name": "rpc",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "shared/rpc/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/shared/rpc",
+        "main": "shared/rpc/src/index.ts",
+        "tsConfig": "shared/rpc/tsconfig.lib.json",
+        "assets": ["shared/rpc/*.md"]
+      }
+    }
+  }
+}

--- a/shared/rpc/src/index.ts
+++ b/shared/rpc/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/rpc';

--- a/shared/rpc/src/lib/rpc.spec.ts
+++ b/shared/rpc/src/lib/rpc.spec.ts
@@ -1,0 +1,153 @@
+import * as amqp from 'amqplib';
+import { EventEmitter } from 'events';
+import { applyOptions } from '@warehouse/logging';
+
+jest.mock('amqplib');
+jest.mock('timers/promises');
+
+const mockSetTimeout = setTimeout as jest.MockedFunction<typeof setTimeout>;
+
+applyOptions({ level: 'critical', label: 'rpc_test' }); // Disable logging
+
+import { RabbitMQClient } from './rpc';
+
+describe('RabbitMQClient Unit Tests', () => {
+  let client: RabbitMQClient;
+  let mockConnection: amqp.Connection;
+  let mockChannel: amqp.Channel;
+  let connectionEmitter: EventEmitter;
+  let channelEmitter: EventEmitter;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    connectionEmitter = new EventEmitter();
+    channelEmitter = new EventEmitter();
+
+    mockChannel = {
+      assertQueue: jest.fn().mockResolvedValue({ queue: 'reply-queue' }),
+      consume: jest.fn(),
+      publish: jest.fn().mockReturnValue(true),
+      close: jest.fn(),
+      on: channelEmitter.on.bind(channelEmitter),
+    } as unknown as amqp.Channel;
+
+    mockConnection = {
+      createChannel: jest.fn().mockResolvedValue(mockChannel),
+      close: jest.fn(),
+      on: connectionEmitter.on.bind(connectionEmitter),
+    } as unknown as amqp.Connection;
+
+    (amqp.connect as jest.Mock).mockImplementation(() =>
+      Promise.resolve(mockConnection)
+    );
+
+    client = new RabbitMQClient({
+      url: 'amqp://localhost',
+      reconnectInterval: 100,
+      maxRetries: 3,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  describe('Initialization', () => {
+    it('should initialize correctly', async () => {
+      await client.init();
+
+      expect(amqp.connect).toHaveBeenCalledWith('amqp://localhost');
+      expect(mockConnection.createChannel).toHaveBeenCalled();
+      expect(client['rpcReplyQueue']).toBe('reply-queue');
+    });
+  });
+
+  describe('Connection Error Handling', () => {
+    it('should handle connection close events', async () => {
+      await client.init();
+      connectionEmitter.emit('close');
+
+      expect(client['connection']).toBeNull();
+      expect(client['channel']).toBeNull();
+    });
+  });
+
+  describe('Reconnection Logic', () => {
+
+    it('should attempt reconnection on connection loss', async () => {
+      await client.init();
+      connectionEmitter.emit('close');
+
+      // Fast-forward time to trigger reconnect
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+
+      expect(amqp.connect).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('RPC Timeout Handling', () => {
+    it('should clean up callbacks after timeout', async () => {
+      await client.init();
+
+      const request = client.rpcRequest('test-queue', {}, { timeout: 100 });
+      jest.advanceTimersByTime(101);
+
+      try {
+        await request;
+      } catch {} // eslint-disable-line
+      expect(client['rpcCallbacks'].size).toBe(0);
+    });
+  });
+
+  describe('EventEmitter Integration', () => {
+    it('should emit connected event', async () => {
+      const connectedSpy = jest.fn();
+      client.on('connected', connectedSpy);
+
+      await client.init();
+
+      expect(connectedSpy).toHaveBeenCalled();
+    });
+
+    it('should emit disconnected event', async () => {
+      await client.init();
+      const disconnectedSpy = jest.fn();
+      client.on('disconnected', disconnectedSpy);
+
+      connectionEmitter.emit('close');
+
+      expect(disconnectedSpy).toHaveBeenCalled();
+    });
+
+    it('should handle multiple event listeners', async () => {
+      const listener1 = jest.fn();
+      const listener2 = jest.fn();
+
+      client.on('connected', listener1);
+      client.on('connected', listener2);
+
+      await client.init();
+
+      expect(listener1).toHaveBeenCalled();
+      expect(listener2).toHaveBeenCalled();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle double close calls', async () => {
+      await client.init();
+      await client.close();
+      await expect(client.close()).resolves.not.toThrow();
+    });
+
+    it('should reject publish without channel', async () => {
+      client['channel'] = null;
+      await expect(
+        client.publish({}, { exchange: 'test', routingKey: 'test' })
+      ).rejects.toThrow('Channel not available');
+    });
+  });
+});

--- a/shared/rpc/src/lib/rpc.ts
+++ b/shared/rpc/src/lib/rpc.ts
@@ -1,0 +1,338 @@
+// rabbitmq-client.ts
+import { getLogger } from '@warehouse/logging';
+import * as amqp from 'amqplib';
+import { EventEmitter } from 'events';
+import { URL } from 'url';
+import { v4 as uuidv4 } from 'uuid';
+
+const logger = getLogger('rabbitmq-client');
+
+interface RabbitMQConfig {
+  url: string | URL;
+  reconnectInterval?: number;
+  maxRetries?: number;
+}
+
+interface PublishOptions {
+  exchange: string;
+  routingKey: string;
+  headers?: Record<string, unknown>;
+  persistent?: boolean;
+}
+
+interface SubscribeOptions {
+  exchange: string;
+  queue: string;
+  routingKey: string;
+  exchangeType?: 'direct' | 'topic' | 'fanout' | 'headers';
+  durable?: boolean;
+  prefetch?: number;
+}
+
+interface RpcOptions {
+  timeout?: number;
+}
+
+export class RabbitMQClient extends EventEmitter {
+  private connection: amqp.Connection | null = null;
+  private channel: amqp.Channel | null = null;
+  private config: RabbitMQConfig;
+  private isConnecting = false;
+  private retryCount = 0;
+  private rpcCallbacks = new Map<string, (msg: Record<string, unknown>) => void>();
+  private rpcReplyQueue: string | null = null; // Храним имя очереди для RPC-ответов
+
+  constructor(config: RabbitMQConfig) {
+    super();
+    this.config = {
+      reconnectInterval: 5000,
+      maxRetries: 10,
+      ...config,
+    };
+  }
+
+  public async init(): Promise<void> {
+    logger.info('Initializing RabbitMQ client');
+    await this.connect();
+    await this.setupRpcResponseQueue();
+    logger.info('RabbitMQ client initialized successfully');
+  }
+
+  private async connect(): Promise<void> {
+    if (this.connection || this.isConnecting) return;
+    this.isConnecting = true;
+    
+    logger.info('Connecting to RabbitMQ...');
+
+    try {
+      this.connection = await amqp.connect(this.config.url as string);
+      this.connection.on('close', this.handleConnectionClose.bind(this));
+      this.connection.on('error', this.handleConnectionError.bind(this));
+
+      this.channel = await this.connection.createChannel();
+      this.retryCount = 0;
+      this.emit('connected');
+      this.isConnecting = false;
+      logger.info('Successfully connected to RabbitMQ');
+    } catch (error) {
+      this.isConnecting = false;
+      logger.error('Failed to connect to RabbitMQ:', error);
+      this.handleConnectionError(error as Error);
+    }
+  }
+
+  // Создаём временную очередь для RPC-ответов и сохраняем её имя
+  private async setupRpcResponseQueue(): Promise<void> {
+    if (!this.channel) throw new Error('Channel not available');
+
+    logger.info('Setting up RPC response queue');
+    const { queue } = await this.channel.assertQueue('', { exclusive: true });
+    this.rpcReplyQueue = queue;
+    logger.info('RPC response queue created', { queue });
+
+    await this.channel.consume(queue, (msg) => {
+      if (!msg) return;
+      const correlationId = msg.properties.correlationId;
+      logger.debug('Received RPC response', { correlationId });
+      const handler = this.rpcCallbacks.get(correlationId);
+      if (handler) {
+        try {
+          const parsed = JSON.parse(msg.content.toString());
+          handler(parsed);
+        } catch (err) {
+          logger.error('Failed to parse JSON response:', err, { correlationId });
+          handler({ error: 'Invalid JSON response' });
+        }
+        this.rpcCallbacks.delete(correlationId);
+      }
+      this.channel?.ack(msg);
+    });
+  }
+
+  private async reconnect(): Promise<void> {
+    if (this.retryCount >= (this.config.maxRetries || 10)) {
+      logger.error('Max reconnection attempts reached');
+      this.emit('error', new Error('Max reconnect attempts reached'));
+      return;
+    }
+
+    this.retryCount++;
+    logger.info('Reconnecting to RabbitMQ in', this.config.reconnectInterval, 'ms');
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, this.config.reconnectInterval ?? 5000)
+    );
+    await this.connect();
+    if (this.channel) {
+      logger.info('Reconnected to RabbitMQ');
+      await this.setupRpcResponseQueue();
+    }
+  }
+
+  private handleConnectionClose(): void {
+    logger.warn('RabbitMQ connection closed');
+    this.emit('disconnected');
+    this.connection = null;
+    this.channel = null;
+    this.rpcReplyQueue = null;
+    this.reconnect();
+  }
+
+  private handleConnectionError(error: Error): void {
+    logger.error('RabbitMQ connection error:', error);
+    this.emit('error', error);
+    this.reconnect();
+  }
+
+  public async publish(
+    message: object,
+    options: PublishOptions
+  ): Promise<boolean> {
+    if (!this.channel) {
+      throw new Error('Channel not available');
+    }
+
+    const { exchange, routingKey, headers, persistent = true } = options;
+    logger.debug('Publishing message', { 
+      exchange, 
+      routingKey,
+      // Note: headers might contain sensitive data
+      headerKeys: headers ? Object.keys(headers) : undefined
+    });
+
+    const buffer = Buffer.from(JSON.stringify(message));
+
+    const result = await this.channel.publish(exchange, routingKey, buffer, {
+      persistent,
+      headers,
+    });
+
+    if (result) {
+      logger.debug('Message published successfully');
+    } else {
+      logger.warn('Message publish returned false', { exchange, routingKey });
+    }
+
+    return result;
+  }
+
+  public async subscribe<T>(
+    options: SubscribeOptions,
+    handler: (msg: T) => Promise<void>
+  ): Promise<void> {
+    if (!this.channel) {
+      throw new Error('Channel not available');
+    }
+
+    const {
+      exchange,
+      exchangeType = 'direct',
+      queue,
+      routingKey,
+      durable = true,
+      prefetch = 10,
+    } = options;
+
+    logger.info('Setting up subscription', { 
+      exchange, 
+      queue, 
+      routingKey, 
+      exchangeType 
+    });
+
+    await this.channel.assertExchange(exchange, exchangeType, { durable });
+    await this.channel.assertQueue(queue, { durable });
+    await this.channel.bindQueue(queue, exchange, routingKey);
+    await this.channel.prefetch(prefetch);
+
+    logger.info('Subscription setup complete, starting consumption', { queue });
+
+    this.channel.consume(queue, async (message) => {
+      if (!message) return;
+
+      logger.debug('Received message', { 
+        queue, 
+        messageId: message.properties.messageId 
+      });
+
+      try {
+        const content = JSON.parse(message.content.toString()) as T;
+        await handler(content);
+        this.channel?.ack(message);
+        logger.debug('Message processed successfully', { 
+          queue, 
+          messageId: message.properties.messageId 
+        });
+      } catch (error) {
+        logger.error('Error processing message:', error, {
+          queue,
+          exchange: options.exchange,
+          routingKey: options.routingKey
+        });
+        this.channel?.nack(message, false, true);
+        this.emit('error', error);
+      }
+    });
+  }
+
+  // RPC-запрос: отправляем сообщение на указанную очередь и ждем ответа в rpcReplyQueue
+  public async rpcRequest<T>(
+    queue: string,
+    message: object,
+    options: RpcOptions = {}
+  ): Promise<T> {
+    if (!this.channel || !this.rpcReplyQueue) {
+      const error = new Error('Channel or RPC reply queue not available');
+      logger.error('RPC request failed:', error);
+      throw error;
+    }
+
+    const correlationId = uuidv4();
+    logger.debug('Sending RPC request', { 
+      queue, 
+      correlationId,
+      timeout: options.timeout || 5000
+    });
+    const timeout = options.timeout || 5000;
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.rpcCallbacks.delete(correlationId);
+        reject(new Error('RPC request timed out'));
+      }, timeout);
+
+      this.rpcCallbacks.set(correlationId, (response) => {
+        clearTimeout(timer);
+        resolve(response as T);
+      });
+
+      try {
+        this.channel?.sendToQueue(queue, Buffer.from(JSON.stringify(message)), {
+          correlationId,
+          replyTo: this.rpcReplyQueue as string | undefined,
+        });
+        logger.debug('RPC request sent successfully', { correlationId });
+      } catch (error) {
+        logger.error('Failed to send RPC request:', error, { queue });
+        clearTimeout(timer);
+        this.rpcCallbacks.delete(correlationId);
+        reject(error);
+      }
+    });
+  }
+
+  // RPC-воркер: обрабатываем запросы из очереди и отправляем ответ, если указаны replyTo и correlationId
+  public async createRpcWorker(
+    queueName: string,
+    handler: (msg: Record<string, unknown>) => Promise<unknown>
+  ): Promise<void> {
+    if (!this.channel) {
+      const error = new Error('Channel not available');
+      logger.error('Failed to create RPC worker:', error);
+      throw error;
+    }
+
+    logger.info('Creating RPC worker', { queueName });
+    await this.channel.assertQueue(queueName, { durable: true });
+    await this.channel.prefetch(1);
+
+    this.channel.consume(queueName, async (msg) => {
+      if (!msg) return;
+
+      const correlationId = msg.properties.correlationId;
+      logger.debug('RPC worker received request', { 
+        queueName, 
+        correlationId 
+      });
+
+      try {
+        const message = JSON.parse(msg.content.toString());
+        const result = await handler(message);
+
+        if (msg.properties.replyTo && msg.properties.correlationId) {
+          this.channel?.sendToQueue(
+            msg.properties.replyTo,
+            Buffer.from(JSON.stringify(result)),
+            { correlationId: msg.properties.correlationId }
+          );
+        }
+        this.channel?.ack(msg);
+        logger.debug('RPC worker processed request', { 
+          queueName, 
+          correlationId 
+        });
+      } catch (error) {
+        logger.error('RPC worker error processing message:', error, { queueName });
+        this.channel?.nack(msg);
+      }
+    });
+  }
+
+  public async close(): Promise<void> {
+    logger.info('Closing RabbitMQ client connection');
+    if (this.channel) await this.channel.close();
+    if (this.connection) await this.connection.close();
+    this.emit('closed');
+    logger.info('RabbitMQ client connection closed');
+  }
+}

--- a/shared/rpc/src/lib/rpc.ts
+++ b/shared/rpc/src/lib/rpc.ts
@@ -33,6 +33,14 @@ interface RpcOptions {
   timeout?: number;
 }
 
+/**
+ * RabbitMQClient is a class that provides an interface for connecting to a RabbitMQ server,
+ * publishing messages, subscribing to queues, and handling RPC requests and responses.
+ * It extends EventEmitter to allow for event-driven programming.
+ *
+ * @class RabbitMQClient
+ * @extends {EventEmitter}
+ */
 export class RabbitMQClient extends EventEmitter {
   private connection: amqp.Connection | null = null;
   private channel: amqp.Channel | null = null;
@@ -54,6 +62,12 @@ export class RabbitMQClient extends EventEmitter {
     };
   }
 
+  /**
+   * Initializes the RabbitMQ client by establishing a connection and setting up the RPC response queue.
+   * Logs the initialization process.
+   * 
+   * @returns {Promise<void>} A promise that resolves when the initialization is complete.
+   */
   public async init(): Promise<void> {
     logger.info('Initializing RabbitMQ client');
     await this.connect();
@@ -61,6 +75,17 @@ export class RabbitMQClient extends EventEmitter {
     logger.info('RabbitMQ client initialized successfully');
   }
 
+  /**
+   * Establishes a connection to RabbitMQ if not already connected.
+   * 
+   * This method attempts to connect to RabbitMQ using the provided configuration URL.
+   * It sets up event listeners for connection close and error events, and creates a channel
+   * for communication. If the connection is successful, it emits a 'connected' event and logs
+   * the success. In case of an error, it logs the failure and handles the connection error.
+   * 
+   * @returns {Promise<void>} A promise that resolves when the connection is successfully established.
+   * @throws {Error} If there is an error during the connection process.
+   */
   private async connect(): Promise<void> {
     if (this.connection || this.isConnecting) return;
     this.isConnecting = true;
@@ -86,7 +111,23 @@ export class RabbitMQClient extends EventEmitter {
     }
   }
 
-  // Создаём временную очередь для RPC-ответов и сохраняем её имя
+  
+  /**
+   * Sets up the RPC response queue for handling responses from RPC calls.
+   * 
+   * This method asserts a new exclusive queue for receiving RPC responses and
+   * sets up a consumer to handle incoming messages. Each message is expected to
+   * have a correlation ID that matches a callback stored in `rpcCallbacks`.
+   * 
+   * If the message content is valid JSON, the corresponding callback is invoked
+   * with the parsed data. If the JSON parsing fails, the callback is invoked with
+   * an error object. After handling the message, it acknowledges the message to
+   * the channel.
+   * 
+   * @throws {Error} If the channel is not available.
+   * 
+   * @returns {Promise<void>} A promise that resolves when the setup is complete.
+   */
   private async setupRpcResponseQueue(): Promise<void> {
     if (!this.channel) throw new Error('Channel not available');
 
@@ -116,6 +157,13 @@ export class RabbitMQClient extends EventEmitter {
     });
   }
 
+  /**
+   * Attempts to reconnect to RabbitMQ with a delay specified in the configuration.
+   * If the maximum number of retries is reached, an error is logged and emitted.
+   * 
+   * @returns {Promise<void>} A promise that resolves when the reconnection attempt is complete.
+   * @throws {Error} If the maximum number of reconnection attempts is reached.
+   */
   private async reconnect(): Promise<void> {
     if (this.retryCount >= (this.config.maxRetries || 10)) {
       logger.error('Max reconnection attempts reached');
@@ -140,6 +188,17 @@ export class RabbitMQClient extends EventEmitter {
     }
   }
 
+  /**
+   * Handles the closure of the RabbitMQ connection.
+   * 
+   * This method performs the following actions:
+   * - Logs a warning message indicating that the RabbitMQ connection has closed.
+   * - Emits a 'disconnected' event.
+   * - Sets the connection, channel, and rpcReplyQueue properties to null.
+   * - Attempts to reconnect by calling the `reconnect` method.
+   * 
+   * @private
+   */
   private handleConnectionClose(): void {
     logger.warn('RabbitMQ connection closed');
     this.emit('disconnected');
@@ -149,6 +208,12 @@ export class RabbitMQClient extends EventEmitter {
     this.reconnect();
   }
 
+  /**
+   * Handles connection errors by logging the error, emitting an 'error' event,
+   * and attempting to reconnect to RabbitMQ.
+   *
+   * @param error - The error object representing the connection error.
+   */
   private handleConnectionError(error: Error): void {
     logger.error('RabbitMQ connection error:', error);
     this.emit('error', error);
@@ -187,6 +252,28 @@ export class RabbitMQClient extends EventEmitter {
     return result;
   }
 
+  /**
+   * Subscribes to a message queue with the given options and handler.
+   * 
+   * @template T - The type of the message content.
+   * @param {SubscribeOptions} options - The subscription options.
+   * @param {(msg: T) => Promise<void>} handler - The handler function to process received messages.
+   * @returns {Promise<void>} A promise that resolves when the subscription is set up.
+   * @throws {Error} If the channel is not available.
+   * 
+   * @example
+   * ```typescript
+   * const options: SubscribeOptions = {
+   *   exchange: 'my_exchange',
+   *   queue: 'my_queue',
+   *   routingKey: 'my_routing_key',
+   * };
+   * 
+   * await rpc.subscribe(options, async (msg) => {
+   *   console.log('Received message:', msg);
+   * });
+   * ```
+   */
   public async subscribe<T>(
     options: SubscribeOptions,
     handler: (msg: T) => Promise<void>
@@ -246,7 +333,18 @@ export class RabbitMQClient extends EventEmitter {
     });
   }
 
-  // RPC-запрос: отправляем сообщение на указанную очередь и ждем ответа в rpcReplyQueue
+  
+  /**
+   * Sends an RPC request to the specified queue with the given message and options.
+   * 
+   * @template T - The expected response type.
+   * @param {string} queue - The name of the queue to send the request to.
+   * @param {object} message - The message to send in the request.
+   * @param {RpcOptions} [options={}] - Optional settings for the RPC request.
+   * @param {number} [options.timeout=5000] - The timeout duration in milliseconds for the RPC request.
+   * @returns {Promise<T>} - A promise that resolves with the response of type T.
+   * @throws {Error} - Throws an error if the channel or RPC reply queue is not available, or if the request times out.
+   */
   public async rpcRequest<T>(
     queue: string,
     message: object,
@@ -292,7 +390,23 @@ export class RabbitMQClient extends EventEmitter {
     });
   }
 
-  // RPC-воркер: обрабатываем запросы из очереди и отправляем ответ, если указаны replyTo и correlationId
+  
+  /**
+   * Creates an RPC worker that listens to a specified queue and processes messages using the provided handler.
+   *
+   * @param queueName - The name of the queue to listen to.
+   * @param handler - A function that processes incoming messages and returns a promise with the result.
+   * @returns A promise that resolves when the RPC worker is successfully created.
+   * @throws Will throw an error if the channel is not available.
+   *
+   * @example
+   * ```typescript
+   * await createRpcWorker('myQueue', async (msg) => {
+   *   // Process the message
+   *   return { success: true };
+   * });
+   * ```
+   */
   public async createRpcWorker(
     queueName: string,
     handler: (msg: Record<string, unknown>) => Promise<unknown>
@@ -341,6 +455,14 @@ export class RabbitMQClient extends EventEmitter {
     });
   }
 
+  /**
+   * Closes the RabbitMQ client connection.
+   * 
+   * This method will close the channel and connection if they are open,
+   * emit a 'closed' event, and log the closure process.
+   * 
+   * @returns {Promise<void>} A promise that resolves when the connection is closed.
+   */
   public async close(): Promise<void> {
     logger.info('Closing RabbitMQ client connection');
     if (this.channel) await this.channel.close();

--- a/shared/rpc/tsconfig.json
+++ b/shared/rpc/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/shared/rpc/tsconfig.lib.json
+++ b/shared/rpc/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/shared/rpc/tsconfig.spec.json
+++ b/shared/rpc/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,6 +16,7 @@
     "baseUrl": ".",
     "paths": {
       "@warehouse/logging": ["shared/logging/src/index.ts"],
+      "@warehouse/rpc": ["shared/rpc/src/index.ts"],
       "@warehouse/validation": ["shared/validation/src/index.ts"]
     }
   },


### PR DESCRIPTION
A library has been created to work with RabbitMQ for microservices.

The library allows you to use the `publish()` and `createRpcWorker()` functions to work with RabbitMQ.